### PR TITLE
Add more navbar styles

### DIFF
--- a/assets/css/chaise.css
+++ b/assets/css/chaise.css
@@ -28,8 +28,14 @@
     font-size: 16px;
 }
 
+.navbar-inverse .navbar-nav>div>a:hover,
 .navbar-inverse .navbar-nav>li>a:hover {
-    background-color: rgb(221, 199, 133, .5);
+    background-color: #407CCA;
+}
+
+.navbar-inverse .navbar-nav>.open>a,
+.navbar-inverse .navbar-nav>.show>a {
+    background-color: #080808;
 }
 
 .navbar-inverse .navbar-nav>li>a:visited {

--- a/assets/css/chaise.css
+++ b/assets/css/chaise.css
@@ -10,6 +10,7 @@
     width: 100%;
     font-size: 16px;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    border: 0;
 }
 
 .navbar-inverse {


### PR DESCRIPTION
Added some rules to make navbar consistent between angularJS navbar and reactJS navbar. The 3 changes made are for the following:
 1. Navbar in angularJS was reported to have `height = 52px` and reactJS had `height = 50px`.
    - added `border: 0` to `.navbar` to override a rule from old version of bootstrap in angularJS
 2. Navbar in angularJS was reported to have a highlighting feature when a top level item was hovered over
    - added `.navbar-inverse .navbar-nav>div>a:hover` to existing rule so this rule applies to both versions of navbar
    - color changed per discussion in slack
 3. Navbar in angularJS changes color to black when a dropdown is opened
    - this was a feature of the navbar in angularJS that we didn't make sure was working in react. This is a bug in reactJS navbar which will be fixed sometime soon
    - in the meantime, a rule was added to replicate this feature for both angularJS and reactJS navbars based on `.show` or `.open` classes

Pages with angularJS navbar:
 - https://staging.atlas-d2k.org/chaise/viewer/#2/Gene_Expression:Image/RID=14-3RDP?waterMark=gudmap.org
 - https://staging.atlas-d2k.org/deriva-webapps/treeview/