### PR TITLE
Update query for Assay Types on homepage

### DIFF
--- a/assets/js/home-stat-queries.js
+++ b/assets/js/home-stat-queries.js
@@ -86,7 +86,7 @@ $(document).ready(function () {
       '#stat-antibody-validation-number',
       '#stat-pubs-number'
     ],
-    "/catalog/2/attributegroup/Dashboard:Release_Status/Consortium=ALL/Species=ALL/ID;Data_Type,Released",
+    "/catalog/2/attributegroup/Dashboard:Release_Status/Consortium=ALL/Species=ALL/!(Released=0)/ID;Data_Type,Released",
     ":,stat/dataset:load",
     "Dashboard:Release_Status"
   );


### PR DESCRIPTION
Change the query made to `Dashboard:Release_Status` to be consistent with the query used for the plot that it links to. This change should filter out the 1 row mentioned in issue #54 that has no "released" data yet.